### PR TITLE
Improve chat UI layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #000;
+  background-color: #f5f5f5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +23,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -54,15 +51,3 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/src/views/ChatView.jsx
+++ b/src/views/ChatView.jsx
@@ -6,8 +6,7 @@ export default function ChatView() {
   const { messages, loading, sendMessage } = useChatViewModel()
   const [input, setInput] = useState('')
 
-  const handleSubmit = (e) => {
-    e.preventDefault()
+  const send = () => {
     const trimmed = input.trim()
     if (trimmed) {
       sendMessage(trimmed)
@@ -15,34 +14,52 @@ export default function ChatView() {
     }
   }
 
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    send()
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send()
+    }
+  }
+
   return (
-    <div className="flex flex-col h-screen max-h-screen">
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
-        {messages.map((m, idx) => (
-          <div key={idx} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-            <div
-              className={`rounded-lg px-3 py-2 max-w-xs break-words ${m.role === 'user' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-800'}`}
-            >
-              {m.text}
+    <div className="h-screen flex flex-col bg-gray-100">
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-2xl p-4 space-y-4">
+          {messages.map((m, idx) => (
+            <div key={idx} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`rounded-xl px-4 py-2 text-sm md:text-base break-words max-w-full ${m.role === 'user' ? 'bg-green-500 text-white' : 'bg-white text-gray-900'}`}
+              >
+                {m.text}
+              </div>
             </div>
-          </div>
-        ))}
-        {loading && (
-          <div className="flex justify-start">
-            <ArrowPathIcon className="h-5 w-5 text-gray-500 animate-spin" />
-          </div>
-        )}
+          ))}
+          {loading && (
+            <div className="flex justify-start">
+              <ArrowPathIcon className="h-5 w-5 text-gray-500 animate-spin" />
+            </div>
+          )}
+        </div>
       </div>
-      <form onSubmit={handleSubmit} className="flex border-t p-4 gap-2">
-        <input
-          className="flex-1 border rounded-md p-2"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="Type your message..."
-        />
-        <button type="submit" className="bg-blue-500 hover:bg-blue-600 text-white rounded-md p-2">
-          <PaperAirplaneIcon className="h-5 w-5" />
-        </button>
+      <form onSubmit={handleSubmit} className="border-t bg-white p-4">
+        <div className="flex mx-auto max-w-2xl gap-2">
+          <textarea
+            className="flex-1 border rounded-md p-2 resize-none"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows="1"
+            placeholder="Type your message..."
+          />
+          <button type="submit" className="bg-blue-500 hover:bg-blue-600 text-white rounded-md p-2">
+            <PaperAirplaneIcon className="h-5 w-5" />
+          </button>
+        </div>
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- make chat window more ChatGPT-like
- center the conversation and redesign message bubbles
- textarea allows multiline input and sending with Enter
- simplify global styles and switch to light theme by default

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872677bcbb48321af8e31004c295c7b