### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=build /app/dist ./dist
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Docker
+
+Build the image and run it to serve the compiled app:
+
+```bash
+docker build -t ollama-chatbot .
+docker run -p 3000:3000 ollama-chatbot
+```
+
+The frontend expects a backend available at `http://localhost:8080/api/ask`.


### PR DESCRIPTION
## Summary
- add a Dockerfile that builds the React app and serves it with `serve`
- document Docker usage in README

## Testing
- `npm ci`
- `npm run lint`